### PR TITLE
Fix : 크루 등록 충돌 해결

### DIFF
--- a/src/main/java/com/example/likelion12/util/JwtProvider.java
+++ b/src/main/java/com/example/likelion12/util/JwtProvider.java
@@ -4,7 +4,6 @@ import com.example.likelion12.domain.Member;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -22,7 +21,7 @@ public class JwtProvider {
 
     // Access Token 생성
     public String createAccessToken(String email, Long memberId) {
-        Claims claims = Jwts.claims().setSubject(email);
+        Claims claims = Jwts.claims().setSubject(email.trim());
         Date now = new Date();
         Date validity = new Date(now.getTime() + accessTokenExpiration);
 
@@ -30,7 +29,7 @@ public class JwtProvider {
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(validity)
-                .claim("memberId",memberId)
+                .claim("memberId", memberId)
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }
@@ -52,7 +51,7 @@ public class JwtProvider {
         try {
             jwtToken = extractJwtToken(authorization);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("유효하지 않은 헤더 포멧입니다.");
+            throw new IllegalArgumentException("유효하지 않은 헤더 포맷입니다.");
         }
 
         // JWT 토큰에서 사용자 정보 추출
@@ -71,9 +70,9 @@ public class JwtProvider {
     public String extractJwtToken(String authorizationHeader) {
         String[] parts = authorizationHeader.split(" ");
         if (parts.length == 2) {
-            return parts[1]; // 토큰 부분 추출
+            return parts[1].trim(); // 토큰 부분 추출 및 공백 제거
         }
-        throw new IllegalArgumentException("유효하지 않은 헤더 포멧입니다.");
+        throw new IllegalArgumentException("유효하지 않은 헤더 포맷입니다.");
     }
 
     public Long extractMemberIdFromJwtToken(String jwtToken) {
@@ -91,5 +90,4 @@ public class JwtProvider {
 
         return memberId;
     }
-
 }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 크루를 등록하는 화면에 대한 api 구현하였습니다. [크루등록 명세서](https://likeklionatkonkuk.notion.site/0ca9d37ea3e54df2bca880c2f1e69377?pvs=4)
- [x] 크루를 만들고 나면 만든 사람이 MemberCrew 테이블에 CAPTAIN 으로 들어갈 수 있도록 구현하였습니다.

## 🔑 변경 사항 (Key Changes)
- `PostCrewRequest/Response dto 작성` : 명세서 대로 구현하였습니다. 
- `Repository 들 작성` : 각 테이블에 대한 레포지토리 파일 작성하였습니다.
- `exception class 작성` : 예외처리를 위한 exception, exceptionHandler 클래스 작성하였습니다.
- `CrewController.createCrew` : 크루등록을 위한 컨트롤러 작성하였습니다.
- `CrewService.createCrew` : 크루 등록을 위한 크루 서비스 작성하였습니다. 멤버크루 생성은 멤버 크루 서비스로 넘겨주었습니다.
- `MemberCrewService.createMemberCrew` : 크루를 만든 사람이 captain 으로 들어갈 수 있도록 구현하였습니다.

## 📝 리뷰 요구사항 (To Reviewers)
- [x] 명세서대로 잘 반환되는지
- [x] 크루가 생겼는지
- [x] 멤버크루에 CAPTAIN 으로 잘 들어가는지

## 확인 방법 
코드를 실행시키고, 레디스도 실행시켜주세요. 
mysql workbench에서 다음 쿼리문을 실행시켜주세요
```
use likelion12;

INSERT INTO exercise (created_at, modified_at,exercise_name, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '축구', 'ACTIVE');

INSERT INTO member (created_at, modified_at, email, member_img, member_name, gender,exercise_id,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'kje2066@nate.com', '프로필 이미지', '김정은', 'F', 1,'ACTIVE');

INSERT INTO activity_region (created_at, modified_at, activity_region_name,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '광진구','ACTIVE');
INSERT INTO facility (created_at, modified_at, facility_name, facility_address, facility_phone,facility_size, administer, 
weekday, weekend, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '광진구 체육관', '광진구 샬라샬라', '000-0000', '3층규모', '서울시','2024-06-30 12:30:00.000000','2024-06-30 12:30:00.000000','ACTIVE');
```

그 다음 카카오 소셜로그인 해주세요.
```
https://kauth.kakao.com/oauth/authorize?client_id=220ac935aaf5aa43884ee21823d82237&redirect_uri=http://localhost:8080/auth/kakao/callback&response_type=code
```
엑세스토큰을 postman 에 넣고 테스트 해주세요.

```
http://localhost:8080/crew
```
다음 주소로 POST 요청 보내주세요
body는 다음과 같이 구성됩니다. (아이디값들은 변경하시면 안됩니다.)
```
{
    "crewName" : "건국런닝",
    "crewImg" : "이미지url",
    "activityRegionId" : 1,
    "facilityId" : 1,
    "exerciseId" : 1,
    "totalRecruits" : 10,
    "crewCost" : 1000,
    "simpleComment" : "간단한 설명",
    "comment" : "크루설명",
    "gender" : "F",
    "level" : "S"
}
```

<img width="443" alt="스크린샷 2024-08-01 오후 3 31 13" src="https://github.com/user-attachments/assets/635c5c74-383b-4da1-b055-ba6ceb5c2375">

다음과 같이 뜨면 성공입니다!

<img width="1152" alt="스크린샷 2024-08-01 오후 3 31 37" src="https://github.com/user-attachments/assets/1502c9b9-0417-47c2-906b-e9bbe8c5c957">
<img width="668" alt="스크린샷 2024-08-01 오후 3 31 58" src="https://github.com/user-attachments/assets/d5e81a2e-c14d-4121-8ee9-439cdb2ee3e4">
데이터베이스에서도 확인가능합니다!
