### PR TITLE
Feat : 참가 예정인 소셜링

### DIFF
--- a/src/main/java/com/example/likelion12/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/likelion12/common/response/status/BaseExceptionResponseStatus.java
@@ -47,6 +47,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     NOT_MEMBERSOCIALRING_CAPTAIN(8001, HttpStatus.BAD_REQUEST.value(), "소셜링 수정,삭제에 접근할수없는 권한입니다."),
     CANNOT_FOUND_MEMBERSOCIALRING_LIST(8002, HttpStatus.BAD_REQUEST.value(), "해당하는 멤버소셜링 리스트를 찾을 수 없습니다."),
     ALREADY_EXIST_IN_SOCIALRING(8003, HttpStatus.BAD_REQUEST.value(), "해당 소셜링에 이미 등록된 멤버입니다."),
+    N0T_EXIST_JOIN_SOCIALRING(8004, HttpStatus.BAD_REQUEST.value(), "참가 중인 소셜링이 존재하지 않습니다."),
+    N0T_EXIST_JOIN_BEFORE_SOCIALRING(8005, HttpStatus.BAD_REQUEST.value(), "참가 예정인 소셜링이 존재 하지않습니다."),
 
     /**
      * 9000 : crew 관련

--- a/src/main/java/com/example/likelion12/controller/SocialringController.java
+++ b/src/main/java/com/example/likelion12/controller/SocialringController.java
@@ -2,15 +2,14 @@ package com.example.likelion12.controller;
 
 import com.example.likelion12.common.response.BaseResponse;
 import com.example.likelion12.common.response.status.BaseExceptionResponseStatus;
-import com.example.likelion12.dto.socialring.GetSocialringDetailResponse;
-import com.example.likelion12.dto.socialring.PatchSocialringModifyRequest;
-import com.example.likelion12.dto.socialring.PostSocialringRequest;
-import com.example.likelion12.dto.socialring.PostSocialringResponse;
+import com.example.likelion12.dto.socialring.*;
 import com.example.likelion12.service.SocialringService;
 import com.example.likelion12.util.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -65,5 +64,15 @@ public class SocialringController {
         Long memberId = jwtProvider.extractIdFromHeader(authorization);
         socialringService.joinSocialring(memberId, socialringId);
         return new BaseResponse<>(BaseExceptionResponseStatus.SUCCESS, null);
+    }
+
+    /**
+     * 참가 예정인 소셜링
+     */
+    @GetMapping("/join/before")
+    public BaseResponse<List<GetSocialringJoinStatusResponse>> joinBeforeSocialring(@RequestHeader("Authorization") String authorization){
+        log.info("[SocialringController.joinBeforeSocialring]");
+        Long memberId = jwtProvider.extractIdFromHeader(authorization);
+        return new BaseResponse<>(socialringService.joinBeforeSocialring(memberId));
     }
 }

--- a/src/main/java/com/example/likelion12/dto/socialring/GetSocialringJoinStatusResponse.java
+++ b/src/main/java/com/example/likelion12/dto/socialring/GetSocialringJoinStatusResponse.java
@@ -1,0 +1,25 @@
+package com.example.likelion12.dto.socialring;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class GetSocialringJoinStatusResponse {
+
+    /**
+     * 소셜링 참여상태 response dto
+     */
+    private Long socialringId;
+    private String socialringName;
+    private String socialringImg;
+    private String activityRegionName;
+    private LocalDate socialringDate;
+    private int socialringCost;
+    private String commentSimple;
+    private int currentRecruits;
+    private int totalRecruits;
+
+}

--- a/src/main/java/com/example/likelion12/repository/MemberSocialringRepository.java
+++ b/src/main/java/com/example/likelion12/repository/MemberSocialringRepository.java
@@ -12,6 +12,7 @@ public interface MemberSocialringRepository extends JpaRepository<MemberSocialri
     Optional<MemberSocialring> findByMember_MemberIdAndSocialring_SocialringIdAndStatus(Long memberId, Long socialringId, BaseStatus status);
     Optional<List<MemberSocialring>> findBySocialring_SocialringIdAndStatus(Long socialringId, BaseStatus baseStatus);
     boolean existsByMember_MemberIdAndSocialring_SocialringIdAndStatus(Long memberId, Long socialringId, BaseStatus status);
+    Optional<List<MemberSocialring>> findByMember_MemberIdAndAndStatus(Long memberId, BaseStatus baseStatus);
 }
 
 

--- a/src/main/java/com/example/likelion12/service/SocialringService.java
+++ b/src/main/java/com/example/likelion12/service/SocialringService.java
@@ -5,10 +5,7 @@ import com.example.likelion12.domain.*;
 import com.example.likelion12.domain.base.BaseGender;
 import com.example.likelion12.domain.base.BaseLevel;
 import com.example.likelion12.domain.base.BaseStatus;
-import com.example.likelion12.dto.socialring.GetSocialringDetailResponse;
-import com.example.likelion12.dto.socialring.PatchSocialringModifyRequest;
-import com.example.likelion12.dto.socialring.PostSocialringRequest;
-import com.example.likelion12.dto.socialring.PostSocialringResponse;
+import com.example.likelion12.dto.socialring.*;
 import com.example.likelion12.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -227,5 +225,58 @@ public class SocialringService {
             // 같으면 전원 모집인 경우라서 가입 불가능
             throw new SocialringException(ALREADY_FULL_SOCIALRING);
         }
+    }
+
+    /**
+     * 참가 예정인 소셜링
+     */
+    @Transactional
+    public List<GetSocialringJoinStatusResponse> joinBeforeSocialring(Long memberId) {
+        log.info("[SocialringService.joinBeforeSocialring]");
+
+        Member member = memberRepository.findByMemberIdAndStatus(memberId, BaseStatus.ACTIVE)
+                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
+
+        //현재 날짜
+        LocalDate nowDate = LocalDate.now();
+
+        // 멤버의 멤버소셜링리스트 추출
+        List<MemberSocialring> memberSocialringList = memberSocialringRepository.findByMember_MemberIdAndAndStatus(memberId,BaseStatus.ACTIVE)
+                .orElseThrow(() -> new MemberSocialringException(CANNOT_FOUND_MEMBERSOCIALRING));
+
+        // 참가중인 소셜링이 없을때 예외처리
+        if(memberSocialringList.isEmpty())
+            throw new MemberSocialringException(N0T_EXIST_JOIN_SOCIALRING);
+
+        // 멤버가 참여한 멤버소셜링 리스트 중에서 현재 날짜보다 더 나중인 소셜링을 추출
+        List<Socialring> memberInjoinBeforeSocialrings = new ArrayList<>();
+        for(MemberSocialring memberSocialring : memberSocialringList ){
+            LocalDate socialringDate = memberSocialring.getSocialring().getSocialringDate();
+            if(socialringDate.isAfter(nowDate)){
+                memberInjoinBeforeSocialrings.add(memberSocialring.getSocialring());
+            }
+        }
+
+        //참가 예정인 소셜링이 존재하지않을떄 예외처리
+        if(memberInjoinBeforeSocialrings.isEmpty())
+            throw new MemberSocialringException(N0T_EXIST_JOIN_BEFORE_SOCIALRING);
+
+        List<GetSocialringJoinStatusResponse> responseList = new ArrayList<>();
+        for(Socialring socialring : memberInjoinBeforeSocialrings ){
+
+            // 현재 참여중인 소셜링원 수 확인하기
+            int currentSocialrings  = memberSocialringRepository.findBySocialring_SocialringIdAndStatus(socialring.getSocialringId(),BaseStatus.ACTIVE)
+                    .orElseThrow(()-> new MemberSocialringException(CANNOT_FOUND_MEMBERSOCIALRING_LIST)).size();
+
+            GetSocialringJoinStatusResponse response = new GetSocialringJoinStatusResponse(socialring.getSocialringId(),
+                    socialring.getSocialringName(),socialring.getSocialringImg(),socialring.getActivityRegion().getActivityRegionName(),
+                    socialring.getSocialringDate(),socialring.getSocialringCost(),socialring.getCommentSimple(),currentSocialrings,
+                    socialring.getTotalRecruits()
+                    );
+            responseList.add(response);
+        }
+
+        return responseList;
+
     }
 }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 참가 예정인 소셜링을 위한 api를 작성했습니다. [ 참가 예정인 소셜링 api 명세서](https://www.notion.so/likeklionatkonkuk/7ff809f847c04502af7b8ca571de281e)
- [x] 사용자가 참여중인 소셜링에서 현재날짜를 기준으로 참가예정인 소셜링 리스트를 반환합니다

## 🔑 변경 사항 (Key Changes)

- `BaseExceptionResponseStatus 추가 작성`  : 참가 예정인 소셜링 관련 예외를 추가작성했습니다.
- `SocialringController.joinBeforeSocialring 작성` : 참가 예정인 소셜링 컨트롤러를 작성했습니다. 
- `GetSocialringJoinStatusResponse dto 작성` : 참가에정/완료 소셜링을 위한 참가상태 반환 dto를 작성했습니다.
- `MemberSocialringRepository.findByMember_MemberIdAndAndStatus 작성` : 사용자가 참여중인 소셜링을 찾기위해 관련 레포지토리를 작성했습니다.
- `SocialringService.joinBeforeSocialring 작성` : 참가 예정인 소셜링 서비스를 작성했습니다.

## 📝 리뷰 요구사항 (To Reviewers)

- [x] 현재날짜를 기준으로 참가 예정인 소셜링 리스트가 제대로 반환되는지
- [x] 예외처리가 적절히 일어나는지

## 확인 방법 
코드를 실행시키고,mysql workbench에서 다음 쿼리문을 실행시켜주세요.
member 중 첫번째 member 를 리뷰자의 정보로 수정해야합니다.

use likelion12;

```
INSERT INTO exercise (created_at, modified_at,exercise_name, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '축구', 'ACTIVE');
INSERT INTO exercise (created_at, modified_at,exercise_name, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '배구', 'ACTIVE');

INSERT INTO member (created_at, modified_at, email, member_img, member_name, gender,exercise_id,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'sungginmama@naver.com', '프로필 이미지', '강희진', 'F', 1,'ACTIVE'); -- 리뷰자 계정
INSERT INTO member (created_at, modified_at, email, member_img, member_name, gender,exercise_id,status) VALUES
('2024-07-30 12:00:00.000000', '2024-07-30 12:30:00.000000', 'kanghuijin12@gmail.com', '프로필 이미지', '강의진', 'F', 1,'ACTIVE');
INSERT INTO member (created_at, modified_at, email, member_img, member_name, gender,exercise_id,status) VALUES
('2024-07-30 12:00:00.000000', '2024-07-30 12:30:00.000000', 'kanghuijin12３@gmail.com', '프로필 이미지', '강', 'F', 2,'ACTIVE');

INSERT INTO activity_region (created_at, modified_at, activity_region_name,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '광진구','ACTIVE');
INSERT INTO activity_region (created_at, modified_at, activity_region_name,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '서초구','ACTIVE');
INSERT INTO facility (created_at, modified_at, facility_name, facility_city,facility_dong,facility_gu, facility_phone, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '광진구 체육관', '서울시','화양동','광진구' ,'000-0000','ACTIVE');
INSERT INTO facility (created_at, modified_at, facility_name, facility_city,facility_dong,facility_gu, facility_phone, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '광진구 체육관2', '서울시2','화양동2','광진구2' ,'000-00002','ACTIVE');

insert INTO socialring(socialring_cost,socialring_date,total_recruits,activity_region_id,created_at,
exercise_id,facility_id,modified_at,comment,comment_simple,socialring_img,socialring_name,gender,level,status) VALUES
(0, '2024-08-07',10,1,'2024-06-30 12:00:00.000000',1,1,'2024-06-30 12:30:00.000000', '소셜링 설명1', '소셜링 한줄설명1','소셜링 이미지1', '소셜링1','F', 'A','ACTIVE');
insert INTO socialring(socialring_cost,socialring_date,total_recruits,activity_region_id,created_at,
exercise_id,facility_id,modified_at,comment,comment_simple,socialring_img,socialring_name,gender,level,status) VALUES
(1000, '2024-08-01',8,1,'2024-06-30 12:00:00.000000',2,1,'2024-06-30 12:30:00.000000', '소셜링 설명2', '소셜링 한줄설명2','소셜링 이미지2', '소셜링2','F', 'S','ACTIVE');
insert INTO socialring(socialring_cost,socialring_date,total_recruits,activity_region_id,created_at,
exercise_id,facility_id,modified_at,comment,comment_simple,socialring_img,socialring_name,gender,level,status) VALUES
(1000, '2024-08-06',5,1,'2024-06-30 12:00:00.000000',2,1,'2024-06-30 12:30:00.000000', '소셜링 설명3', '소셜링 한줄설명3','소셜링 이미지3', '소셜링3','F', 'S','ACTIVE');

insert INTO member_socialring(created_at,member_id,modified_at,socialring_id,role,status) values
('2024-06-30 12:00:00.000000',1,'2024-06-30 12:30:00.000000',1,'CAPTAIN','ACTIVE'),-- 첫 번째 소셜링, 첫 번째 멤버
('2024-06-30 12:00:00.000000',3,'2024-06-30 12:30:00.000000',1,'CREW','ACTIVE'), -- 첫 번째 소셜링, 세 번째 멤버
('2024-06-30 12:00:00.000000',2,'2024-06-30 12:30:00.000000',2,'CAPTAIN','ACTIVE'), -- 두 번째 소셜링, 두 번째 멤버
('2024-06-30 12:00:00.000000',3,'2024-06-30 12:30:00.000000',2,'CREW','ACTIVE'), -- 두 번째 소셜링, 세 번째 멤버
('2024-06-30 12:00:00.000000',1,'2024-06-30 12:30:00.000000',2,'CREW','ACTIVE'), -- 두 번째 소셜링, 첫 번째 멤버
('2024-06-30 12:00:00.000000',1,'2024-06-30 12:30:00.000000',3,'CAPTAIN','ACTIVE'); -- 세 번째 소셜링, 첫 번째 멤버
```
그 다음 카카오 소셜 로그인을 해주세요.

`https://kauth.kakao.com/oauth/authorize?client_id=220ac935aaf5aa43884ee21823d82237&redirect_uri=http://localhost:8080/auth/kakao/callback&response_type=code`

엑세스토큰을 postman에 넣고 테스트 해주세요

다음 주소로 GET 요청 보내주세요

`http://localhost:8080/socialring/join/before`

![image](https://github.com/user-attachments/assets/0a5e7b37-f24c-482c-a609-9fc9fe4816b9)

현재날짜 (8/4)를 기준으로 소셜링날짜가 (8/7),(8/10)인 소셜링1,3이 반환되면 성공입니다! 소셜링2는 (8/1)이므로 반환되면 안됩니다!

다음으로 인텔리제이를 다시 실행시킨뒤 쿼리문에서 멤버소셜링 부분을 아래와같이 수정해주세요
```
('2024-06-30 12:00:00.000000',2,'2024-06-30 12:30:00.000000',1,'CAPTAIN','ACTIVE'),-- 첫 번째 소셜링, 두 번째 멤버
('2024-06-30 12:00:00.000000',2,'2024-06-30 12:30:00.000000',2,'CAPTAIN','ACTIVE'), -- 두 번째 소셜링, 두 번째 멤버
('2024-06-30 12:00:00.000000',3,'2024-06-30 12:30:00.000000',3,'CAPTAIN','ACTIVE'); -- 세 번째 소셜링, 세 번째 멤버
```

![image](https://github.com/user-attachments/assets/7fc17ad4-6d2c-4978-bff7-0b9f3d59dbbb)
멤버1은 참여하고있는 소셜링이 없기떄문에 위와같은 결과가 떠야합니다!

마지막으로 인텔리제이를 재실행 시키지말고 

`('2024-06-30 12:00:00.000000',1,'2024-06-30 12:30:00.000000',2,'CREW','ACTIVE'); -- 두 번째 소셜링, 첫 번째 멤버`

위의 쿼리문 한줄만 실행시켜주세요
위의 세 번째 소셜링, 세 번째 멤버 쿼리문의 마지막줄을 ; 말고 , 으로 바꿔야 오류안납니다!

![image](https://github.com/user-attachments/assets/c4d2ff23-990d-4159-b4d4-606a6c3ca3ba)

소셜링2에 멤버1을 참여시켰지만 소셜링2 날짜가 (8/1)이므로 위와같은 결과가 떠야합니다!

