### PR TITLE
Feat : 참가 완료한 소셜링

### DIFF
--- a/src/main/java/com/example/likelion12/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/likelion12/common/response/status/BaseExceptionResponseStatus.java
@@ -49,6 +49,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     ALREADY_EXIST_IN_SOCIALRING(8003, HttpStatus.BAD_REQUEST.value(), "해당 소셜링에 이미 등록된 멤버입니다."),
     N0T_EXIST_JOIN_SOCIALRING(8004, HttpStatus.BAD_REQUEST.value(), "참가 중인 소셜링이 존재하지 않습니다."),
     N0T_EXIST_JOIN_BEFORE_SOCIALRING(8005, HttpStatus.BAD_REQUEST.value(), "참가 예정인 소셜링이 존재 하지않습니다."),
+    N0T_EXIST_JOIN_COMPLETE_SOCIALRING(8005, HttpStatus.BAD_REQUEST.value(), "참가 완료한 소셜링이 존재 하지않습니다."),
 
     /**
      * 9000 : crew 관련

--- a/src/main/java/com/example/likelion12/controller/SocialringController.java
+++ b/src/main/java/com/example/likelion12/controller/SocialringController.java
@@ -75,4 +75,16 @@ public class SocialringController {
         Long memberId = jwtProvider.extractIdFromHeader(authorization);
         return new BaseResponse<>(socialringService.joinBeforeSocialring(memberId));
     }
+
+    /**
+     * 참가 완료한 소셜링
+     */
+    @GetMapping("/join/complete")
+    public BaseResponse<List<GetSocialringJoinStatusResponse>> joinCompleteSocialring(@RequestHeader("Authorization") String authorization){
+        log.info("[SocialringController.joinCompleteSocialring]");
+        Long memberId = jwtProvider.extractIdFromHeader(authorization);
+        return new BaseResponse<>(socialringService.joinCompleteSocialring(memberId));
+    }
+
+
 }

--- a/src/main/java/com/example/likelion12/service/SocialringService.java
+++ b/src/main/java/com/example/likelion12/service/SocialringService.java
@@ -279,4 +279,56 @@ public class SocialringService {
         return responseList;
 
     }
+
+    /**
+     * 참가 완료한 소셜링
+     */
+    @Transactional
+    public List<GetSocialringJoinStatusResponse> joinCompleteSocialring(Long memberId) {
+        log.info("[SocialringService.joinCompleteSocialring]");
+
+        Member member = memberRepository.findByMemberIdAndStatus(memberId, BaseStatus.ACTIVE)
+                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
+
+        //현재 날짜
+        LocalDate nowDate = LocalDate.now();
+
+        // 멤버의 멤버소셜링리스트 추출
+        List<MemberSocialring> memberSocialringList = memberSocialringRepository.findByMember_MemberIdAndAndStatus(memberId,BaseStatus.ACTIVE)
+                .orElseThrow(() -> new MemberSocialringException(CANNOT_FOUND_MEMBERSOCIALRING));
+
+        // 참가중인 소셜링이 없을때 예외처리
+        if(memberSocialringList.isEmpty())
+            throw new MemberSocialringException(N0T_EXIST_JOIN_SOCIALRING);
+
+        // 멤버가 참여한 멤버소셜링 리스트 중에서 현재 날짜보다 더 전인 소셜링을 추출
+        List<Socialring> memberInjoinBeforeSocialrings = new ArrayList<>();
+        for(MemberSocialring memberSocialring : memberSocialringList ){
+            LocalDate socialringDate = memberSocialring.getSocialring().getSocialringDate();
+            if(socialringDate.isBefore(nowDate)){
+                memberInjoinBeforeSocialrings.add(memberSocialring.getSocialring());
+            }
+        }
+
+        //참가 예정인 소셜링이 존재하지않을떄 예외처리
+        if(memberInjoinBeforeSocialrings.isEmpty())
+            throw new MemberSocialringException(N0T_EXIST_JOIN_COMPLETE_SOCIALRING);
+
+        List<GetSocialringJoinStatusResponse> responseList = new ArrayList<>();
+        for(Socialring socialring : memberInjoinBeforeSocialrings ){
+
+            // 현재 참여중인 소셜링원 수 확인하기
+            int currentSocialrings  = memberSocialringRepository.findBySocialring_SocialringIdAndStatus(socialring.getSocialringId(),BaseStatus.ACTIVE)
+                    .orElseThrow(()-> new MemberSocialringException(CANNOT_FOUND_MEMBERSOCIALRING_LIST)).size();
+
+            GetSocialringJoinStatusResponse response = new GetSocialringJoinStatusResponse(socialring.getSocialringId(),
+                    socialring.getSocialringName(),socialring.getSocialringImg(),socialring.getActivityRegion().getActivityRegionName(),
+                    socialring.getSocialringDate(),socialring.getSocialringCost(),socialring.getCommentSimple(),currentSocialrings,
+                    socialring.getTotalRecruits()
+            );
+            responseList.add(response);
+        }
+
+        return responseList;
+    }
 }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 참가 완료한 소셜링을 위한 api를 작성했습니다. [ 참가 완료 소셜링 api 명세서](https://www.notion.so/likeklionatkonkuk/b20e5c1dd714443a82b9b6fc85d9cbc1)
- [x] 사용자가 참여중인 소셜링에서 현재날짜를 기준으로 참가완료한 소셜링 리스트를 반환합니다

## 🔑 변경 사항 (Key Changes)

- `BaseExceptionResponseStatus 추가 작성`  : 참가 완료한 소셜링 관련 예외를 추가작성했습니다.
- `SocialringController.joinCompleteSocialring 작성` : 참가 완료한 소셜링 컨트롤러를 작성했습니다. 
-  `SocialringService.joinCompleteSocialring 작성` : 참가 완료한 소셜링 서비스를 작성했습니다.

## 📝 리뷰 요구사항 (To Reviewers)

- [ ] 현재날짜를 기준으로 참가 완료한 리스트가 제대로 반환되는지
- [ ] 예외처리가 적절히 일어나는지

## 확인 방법 

코드를 실행시키고,mysql workbench에서 다음 쿼리문을 실행시켜주세요.
member 중 첫번째 member 를 리뷰자의 정보로 수정해야합니다.
```
use likelion12;

INSERT INTO exercise (created_at, modified_at,exercise_name, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '축구', 'ACTIVE');
INSERT INTO exercise (created_at, modified_at,exercise_name, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '배구', 'ACTIVE');

INSERT INTO member (created_at, modified_at, email, member_img, member_name, gender,exercise_id,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'sungginmama@naver.com', '프로필 이미지', '강희진', 'F', 1,'ACTIVE'); -- 리뷰자 계정
INSERT INTO member (created_at, modified_at, email, member_img, member_name, gender,exercise_id,status) VALUES
('2024-07-30 12:00:00.000000', '2024-07-30 12:30:00.000000', 'kanghuijin12@gmail.com', '프로필 이미지', '강의진', 'F', 1,'ACTIVE');
INSERT INTO member (created_at, modified_at, email, member_img, member_name, gender,exercise_id,status) VALUES
('2024-07-30 12:00:00.000000', '2024-07-30 12:30:00.000000', 'kanghuijin12３@gmail.com', '프로필 이미지', '강', 'F', 2,'ACTIVE');

INSERT INTO activity_region (created_at, modified_at, activity_region_name,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '광진구','ACTIVE');
INSERT INTO activity_region (created_at, modified_at, activity_region_name,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '서초구','ACTIVE');
INSERT INTO facility (created_at, modified_at, facility_name, facility_city,facility_dong,facility_gu, facility_phone, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '광진구 체육관', '서울시','화양동','광진구' ,'000-0000','ACTIVE');
INSERT INTO facility (created_at, modified_at, facility_name, facility_city,facility_dong,facility_gu, facility_phone, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '광진구 체육관2', '서울시2','화양동2','광진구2' ,'000-00002','ACTIVE');

insert INTO socialring(socialring_cost,socialring_date,total_recruits,activity_region_id,created_at,
exercise_id,facility_id,modified_at,comment,comment_simple,socialring_img,socialring_name,gender,level,status) VALUES
(0, '2024-08-03',10,1,'2024-06-30 12:00:00.000000',1,1,'2024-06-30 12:30:00.000000', '소셜링 설명1', '소셜링 한줄설명1','소셜링 이미지1', '소셜링1','F', 'A','ACTIVE');
insert INTO socialring(socialring_cost,socialring_date,total_recruits,activity_region_id,created_at,
exercise_id,facility_id,modified_at,comment,comment_simple,socialring_img,socialring_name,gender,level,status) VALUES
(1000, '2024-08-08',8,1,'2024-06-30 12:00:00.000000',2,1,'2024-06-30 12:30:00.000000', '소셜링 설명2', '소셜링 한줄설명2','소셜링 이미지2', '소셜링2','F', 'S','ACTIVE');
insert INTO socialring(socialring_cost,socialring_date,total_recruits,activity_region_id,created_at,
exercise_id,facility_id,modified_at,comment,comment_simple,socialring_img,socialring_name,gender,level,status) VALUES
(1000, '2024-08-01',5,1,'2024-06-30 12:00:00.000000',2,1,'2024-06-30 12:30:00.000000', '소셜링 설명3', '소셜링 한줄설명3','소셜링 이미지3', '소셜링3','F', 'S','ACTIVE');

insert INTO member_socialring(created_at,member_id,modified_at,socialring_id,role,status) values
('2024-06-30 12:00:00.000000',1,'2024-06-30 12:30:00.000000',1,'CAPTAIN','ACTIVE'),-- 첫 번째 소셜링, 첫 번째 멤버
('2024-06-30 12:00:00.000000',3,'2024-06-30 12:30:00.000000',1,'CREW','ACTIVE'), -- 첫 번째 소셜링, 세 번째 멤버
('2024-06-30 12:00:00.000000',2,'2024-06-30 12:30:00.000000',2,'CAPTAIN','ACTIVE'), -- 두 번째 소셜링, 두 번째 멤버
('2024-06-30 12:00:00.000000',3,'2024-06-30 12:30:00.000000',2,'CREW','ACTIVE'), -- 두 번째 소셜링, 세 번째 멤버
('2024-06-30 12:00:00.000000',1,'2024-06-30 12:30:00.000000',2,'CREW','ACTIVE'), -- 두 번째 소셜링, 첫 번째 멤버
('2024-06-30 12:00:00.000000',1,'2024-06-30 12:30:00.000000',3,'CAPTAIN','ACTIVE'); -- 세 번째 소셜링, 첫 번째 멤버
```
그 다음 카카오 소셜 로그인을 해주세요.

`https://kauth.kakao.com/oauth/authorize?client_id=220ac935aaf5aa43884ee21823d82237&redirect_uri=http://localhost:8080/auth/kakao/callback&response_type=code`

엑세스토큰을 postman에 넣고 테스트 해주세요

다음 주소로 GET 요청 보내주세요

`http://localhost:8080/socialring/join/complete`

![image](https://github.com/user-attachments/assets/36a07868-ecab-4ada-bd74-a713952803dc)

현재날짜 (8/4)를 기준으로 소셜링날짜가 (8/3),(8/1)인 소셜링1,3이 반환되면 성공입니다! 소셜링2는 (8/8)이므로 반환되면 안됩니다!

다음으로 인텔리제이를 다시 실행시킨뒤 쿼리문에서 멤버소셜링 부분을 아래와같이 수정해주세요
```
('2024-06-30 12:00:00.000000',2,'2024-06-30 12:30:00.000000',1,'CAPTAIN','ACTIVE'),-- 첫 번째 소셜링, 두 번째 멤버
('2024-06-30 12:00:00.000000',2,'2024-06-30 12:30:00.000000',2,'CAPTAIN','ACTIVE'), -- 두 번째 소셜링, 두 번째 멤버
('2024-06-30 12:00:00.000000',3,'2024-06-30 12:30:00.000000',3,'CAPTAIN','ACTIVE'); -- 세 번째 소셜링, 세 번째 멤버
```

![image](https://github.com/user-attachments/assets/faddd25c-0291-44df-bf6a-d2b1b24d38d4)
멤버1은 참여하고있는 소셜링이 없기떄문에 위와같은 결과가 떠야합니다!

마지막으로 인텔리제이를 재실행 시키지말고

`('2024-06-30 12:00:00.000000',1,'2024-06-30 12:30:00.000000',2,'CREW','ACTIVE'); -- 두 번째 소셜링, 첫 번째 멤버`

위의 쿼리문 한줄만 실행시켜주세요
위의 세 번째 소셜링, 세 번째 멤버 쿼리문의 마지막줄을 ; 말고 , 으로 바꿔야 오류안납니다!

![image](https://github.com/user-attachments/assets/264d5a14-275f-4174-91b3-35295b293f3a)

소셜링2에 멤버1을 참여시켰지만 소셜링2 날짜가 (8/8)이므로 위와같은 결과가 떠야합니다!

