### PR TITLE
Feat : 크루 탈퇴하기

### DIFF
--- a/src/main/java/com/example/likelion12/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/example/likelion12/common/response/status/BaseExceptionResponseStatus.java
@@ -64,6 +64,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     ALREADY_EXIST_IN_CREW(10002, HttpStatus.BAD_REQUEST.value(), "해당 크루에 이미 등록된 멤버입니다."),
     NOT_MEMBERCREW_CAPTAIN(10003, HttpStatus.BAD_REQUEST.value(), "크루 수정,삭제에 접근할수없는 권한입니다."),
     NOT_CREW_MEMBERCREW(10004, HttpStatus.BAD_REQUEST.value(), "해당 크루에 참여 상태가 아닙니다."),
+    CANNOT_CREW_CANCEL(10005, HttpStatus.BAD_REQUEST.value(), "해당 크루를 탈퇴 할 수 없습니다. 크루 삭제를 이용해주세요."),
 
     /**
      * 11000 : Review 관련

--- a/src/main/java/com/example/likelion12/service/CrewService.java
+++ b/src/main/java/com/example/likelion12/service/CrewService.java
@@ -4,6 +4,7 @@ import com.example.likelion12.common.exception.*;
 import com.example.likelion12.domain.*;
 import com.example.likelion12.domain.base.BaseGender;
 import com.example.likelion12.domain.base.BaseLevel;
+import com.example.likelion12.domain.base.BaseRole;
 import com.example.likelion12.domain.base.BaseStatus;
 import com.example.likelion12.dto.crew.GetCrewDetailResponse;
 import com.example.likelion12.dto.crew.PostCrewRequest;
@@ -194,22 +195,27 @@ public class CrewService {
 
         // 크루를 탈퇴하고자 하는  member
         Member member = memberRepository.findByMemberIdAndStatus(memberId, BaseStatus.ACTIVE)
-                .orElseThrow(()-> new MemberException(CANNOT_FOUND_MEMBER));
+                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
 
         //탈퇴하고자 하는 크루
         Crew crew = crewRepository.findByCrewIdAndStatus(crewId, BaseStatus.ACTIVE)
-                .orElseThrow(()->new CrewException(CANNOT_FOUND_CREW));
+                .orElseThrow(() -> new CrewException(CANNOT_FOUND_CREW));
 
         //탈퇴하고자 하는 크루의 멤버크루
         //해당크루와 관계없음(해당크루에 등록되있지 않음), 멤버크루가 존재하지않음
-        MemberCrew memberCrew = memberCrewRepository.findByMember_MemberIdAndCrew_CrewIdAndStatus( memberId, crewId, BaseStatus.ACTIVE)
-                .orElseThrow(()->new MemberCrewException(NOT_CREW_MEMBERCREW));
+        MemberCrew memberCrew = memberCrewRepository.findByMember_MemberIdAndCrew_CrewIdAndStatus(memberId, crewId, BaseStatus.ACTIVE)
+                .orElseThrow(() -> new MemberCrewException(NOT_CREW_MEMBERCREW));
 
-        //CAPTAIN일 경우 크루 삭제
-        if(memberCrewService.ConfirmCaptainMemberCrew(memberCrew))
-            deleteCrew(memberId,crewId);
-        else //크루 탈퇴
-        memberCrewRepository.delete(memberCrew);
+        //CAPTAIN일 경우 예외처리 --> 크루삭제
+        if (BaseRole.CAPTAIN.equals(memberCrew.getRole())){
+            throw new MemberCrewException(CANNOT_CREW_CANCEL);
+        }
+        //크루 탈퇴
+        else {
+            //멤버크루 삭제
+            memberCrew.DeleteMemberCrewInfo(BaseStatus.DELETE);
+            memberCrewRepository.save(memberCrew);
+       }
 
     }
 }

--- a/src/main/java/com/example/likelion12/service/MemberCrewService.java
+++ b/src/main/java/com/example/likelion12/service/MemberCrewService.java
@@ -45,12 +45,11 @@ public class MemberCrewService {
     /**
      * 크루 수정,삭제 시 접근하는 member가 CAPTAIN 인지 확인
      */
-    public boolean ConfirmCaptainMemberCrew(MemberCrew memberCrew) {
+    public void ConfirmCaptainMemberCrew(MemberCrew memberCrew) {
         log.info("[MemberCrewService.ConfirmCaptainMemberCrew]");
 
         if (!BaseRole.CAPTAIN.equals(memberCrew.getRole())) {
             throw new MemberCrewException(NOT_MEMBERCREW_CAPTAIN);
         }
-        return true;
     }
 }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 크루 탈퇴하기 화면에 대한 api를 구현했습니다. [크루탈퇴 명세서](https://www.notion.so/likeklionatkonkuk/c737347b09e64dd29c89ccdc669bd20b)
- [x]  크루를 탈퇴하고자 하는  Member가 CREW일 경우에만 탈퇴가능하도록 구현했습니다. 

## 🔑 변경 사항 (Key Changes)

- `BaseExceptionResponseStatus 추가 작성`  : 크루 탈퇴 관련한 예외를 추가 작성했습니다.
- `CrewService.cancelCrew 작성`  : 크루 탈퇴하기 서비스를 작성했습니다.
- ` CrewController.deleteCrew 작성`  : 크루 탈퇴하기 컨트롤러를 작성했습니다.

## 📝 리뷰 요구사항 (To Reviewers)

- [ ] 크루 탈퇴가 제대로되는지
- [ ] CAPTAIN 인 멤버가 탈퇴를 하려고할떄 적절한 예외처리가 일어나는지 
- [ ] 접근할 수 없는 크루에 대한 예외처리가 제대로 되는지

## 확인 방법 

코드를 실행시키고,mysql workbench에서 다음 쿼리문을 실행시켜주세요.
첫번째 member를 리뷰자의 정보로 수정해야합니다.

```
use likelion12;

INSERT INTO exercise (created_at, modified_at,exercise_name, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '축구', 'ACTIVE');
INSERT INTO exercise (created_at, modified_at,exercise_name, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '농구', 'ACTIVE');

INSERT INTO member (created_at, modified_at, email, member_img, member_name, gender,exercise_id,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', 'sungginmama@naver.com', '프로필 이미지', '강희진', 'F', 1,'ACTIVE'); -- 리뷰자 계정
INSERT INTO member (created_at, modified_at, email, member_img, member_name, gender,exercise_id,status) VALUES
('2024-07-30 12:00:00.000000', '2024-07-30 12:30:00.000000', 'kanghuijin12@gmail.com', '프로필 이미지', '강의진', 'F', 1,'ACTIVE');
INSERT INTO member (created_at, modified_at, email, member_img, member_name, gender,exercise_id,status) VALUES
('2024-07-30 12:00:00.000000', '2024-07-30 12:30:00.000000', 'kanghuijin12３@gmail.com', '프로필 이미지', '강', 'F', 2,'ACTIVE');

INSERT INTO activity_region (created_at, modified_at, activity_region_name,status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '광진구','ACTIVE');
INSERT INTO facility (created_at, modified_at, facility_name, facility_city,facility_dong,facility_gu, facility_phone, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '광진구 체육관', '서울시','화양동','광진구' ,'000-0000','ACTIVE');
INSERT INTO facility (created_at, modified_at, facility_name, facility_city,facility_dong,facility_gu, facility_phone, status) VALUES
('2024-06-30 12:00:00.000000', '2024-06-30 12:30:00.000000', '광진구 체육관2', '서울시2','화양동2','광진구2' ,'000-00002','ACTIVE');

INSERT INTO crew (crew_cost, total_recruits, activity_region_id, created_at, exercise_id, facility_id, modified_at, comment, comment_simple, crew_img, crew_name, gender, level, status) VALUES
(1500, 50, 1, '2024-08-01 09:00:00', 1, 2, '2024-08-01 09:00:00', '크루1입니다~', '크루1', '크루1.png', '크루1', 'M', 'A', 'ACTIVE');
INSERT INTO crew (crew_cost, total_recruits, activity_region_id, created_at, exercise_id, facility_id, modified_at, comment, comment_simple, crew_img, crew_name, gender, level, status) VALUES
(1200, 40, 1, '2024-08-02 10:00:00', 1, 2, '2024-08-02 10:00:00', '크루2입니다~', '크루2', '크루2.png', '크루2', 'F', 'S', 'ACTIVE');
INSERT INTO crew (crew_cost, total_recruits, activity_region_id, created_at, exercise_id, facility_id, modified_at, comment, comment_simple, crew_img, crew_name, gender, level, status) VALUES
(1200, 40, 1, '2024-08-02 10:00:00', 2, 1, '2024-08-02 10:00:00', '크루3입니다~', '크루3', '크루3.png', '크루3', 'F', 'S', 'ACTIVE');

INSERT INTO member_crew (role, status, crew_id, member_id, created_at, modified_at) VALUES
('CAPTAIN', 'ACTIVE', 1, 1, '2024-08-01 09:00:00', '2024-08-01 09:00:00'), -- 첫 번째 크루, 첫 번째 멤버(CAPTAIN)
('CREW', 'ACTIVE', 1, 3, '2024-08-01 09:00:00', '2024-08-01 09:00:00'), -- 첫 번째 크루, 세 번째 멤버
('CREW', 'ACTIVE', 2, 1, '2024-08-02 10:00:00', '2024-08-02 10:00:00'), -- 두 번째 크루, 첫 번째 멤버
('CREW', 'ACTIVE', 2, 2, '2024-08-02 10:00:00', '2024-08-02 10:00:00'), -- 두 번째 크루, 두 번째 멤버
('CAPTAIN', 'ACTIVE', 2, 3, '2024-08-02 10:00:00', '2024-08-02 10:00:00'), -- 두 번째 크루, 세 번째 멤버
('CAPTAIN', 'ACTIVE', 3, 2, '2024-08-02 10:00:00', '2024-08-02 10:00:00'); -- 세 번째 크루, 두 번째 멤버
```

그 다음 카카오 소셜 로그인을 해주세요.

`https://kauth.kakao.com/oauth/authorize?client_id=220ac935aaf5aa43884ee21823d82237&redirect_uri=http://localhost:8080/auth/kakao/callback&response_type=code`

엑세스토큰을 postman에 넣고 테스트 해주세요

다음 주소로 PATCH 요청 보내주세요

`http://localhost:8080/crew/cancel?crewId=1`

crewId값을 변경해 가면서 변경사항을 확인하시면 됩니다!

![image](https://github.com/user-attachments/assets/21ffe464-a963-4d81-b9d7-082981e518a0)

크루 탈퇴전 멤버크루의 데이터베이스 상태입니다.

![image](https://github.com/user-attachments/assets/bbd02c8e-bcac-4754-9359-ab62df0d6ace)

![image](https://github.com/user-attachments/assets/282dfccf-f06f-4a06-99df-04d4a008436e)

크루아이디2 CREW 권한을 가진 멤버아이디1이 크루2 탈퇴를 했을때 정상적으로 상태값이 DELETE로 변경되는것을 확인할 수 있습니다!

![image](https://github.com/user-attachments/assets/1ebc9ad9-9242-43d2-90c8-3bf1afd392f7)

반면 크루아이디1의 CAPTAIN 권한을 가진 멤버아이디1이 크루1 탈퇴를 하려고하면 위와같은 예외처리가 되어야 성공입니다!

![image](https://github.com/user-attachments/assets/9e1eb4ba-2fe6-4cc3-b018-3f35bd178f0f)

크루아이디3에 참여하고 있지않은 멤버아이디1이 크루3 탈퇴를 하려고했을때
위와같은 메세지가 뜨면 성공입니다!

![image](https://github.com/user-attachments/assets/846e39ba-fb20-4a75-b53f-a18388bfec69)

크루아이디4 이상부터는 존재하지않는 크루에대한 예외처리 메세지가 뜨면 성공입니다!

크루아이디1 - > 크루탈퇴 불가 (CAPTAIN이라서)
크루아이디2 - > 크루탈퇴
크루아이디3 - > 크루에 참여하지 못한 상태라 삭제 불가
크루아이디4 이상 -> 존재하지 않는 크루에대한 예외처리